### PR TITLE
Demonstrates how "UWP XAML controls rely on templates to describe the…

### DIFF
--- a/ControlCorral/MainPage.xaml
+++ b/ControlCorral/MainPage.xaml
@@ -14,7 +14,20 @@
             HorizontalAlignment="Center"
             VerticalAlignment="Center"
             Command="{Binding}"
-            CommandParameter="make a reservation"/>
+            CommandParameter="make a reservation">
+            <Button.Template>
+                <ControlTemplate TargetType="Button">
+                    <Border Width="200"
+                        Height="100"
+                        CornerRadius="20"
+                        Background="{TemplateBinding Background}">
+                        <ContentControl Content="{TemplateBinding Content}"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
 
+            </Button.Template>
+        </Button>
     </Grid>
 </Page>


### PR DESCRIPTION
…ir user interfaces, and how any of these templates can be overridden to create customer interfaces, without losing their base functionality.

This example makes the Button in the example a bit larger and gives it rounded corners.  Note that default interface included animations for mouse-clicks (for example) that are not described in the new, overriding template, and these animations are lost.